### PR TITLE
Replace in-place bashing of transient with atom.

### DIFF
--- a/src/main/clojure/clara/rules.clj
+++ b/src/main/clojure/clara/rules.clj
@@ -45,7 +45,7 @@
 (defmacro == 
   "Unifies a variable with a given value. This should be used only inside the definition of a rule."
   [variable content]
-  `(do (assoc! ~'?__bindings__ ~(keyword variable) ~content)
+  `(do (swap! ~'?__bindings__ assoc ~(keyword variable) ~content)
        ~content)) ;; TODO: This might be better to use a dynamic var to create bindings.
 
 (defn insert! 

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -482,10 +482,10 @@
               {:tag (symbol (.getName type))})] ; Add type hint to avoid runtime refection.
 
        (let [~@assignments
-             ~'?__bindings__ (transient ~initial-bindings)]
+             ~'?__bindings__ (atom ~initial-bindings)]
 
          (if (and ~@constraints)
-           (persistent! ~'?__bindings__)
+           (deref ~'?__bindings__)
            nil)))))
 
 (defn compile-action [binding-keys rhs]


### PR DESCRIPTION
Transients improve performance by dropping persistence, but the interface they expose is still functional. It's an error to bash them in-place vs use the return values of `assoc!` etc, and only works (or appears to work) when the number of modifications is relatively small.

Fortunately it's a simple change to bash an atom instead, which is what they're there for :-).
