### PR TITLE
Remove need to AOT compile.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,5 +13,4 @@
   :javadoc-opts {:package-names ["clara.rules"]}
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"]
-  :java-source-paths ["src/main/java"]
-  :aot :all)
+  :java-source-paths ["src/main/java"])

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -438,11 +438,17 @@
         (doseq [token matched-tokens]
           (send-accumulated node accumulator token reduced bindings transport memory))))))
 
+(def ^:private reflector
+  "For some reason (bug?) the default reflector doesn't use the
+  Clojure dynamic class loader, which prevents reflecting on
+  `defrecords`.  Work around by supplying our own which does."
+  (clojure.reflect.JavaReflector. (clojure.lang.RT/baseLoader)))
+
 (defn- get-field-accessors
   "Returns a map of field name to a symbol representing the function used to access it."
   [cls]
   (into {}
-        (for [member (:members (reflect/type-reflect cls))
+        (for [member (:members (reflect/type-reflect cls :reflector reflector))
               :when  (and (:type member) 
                           (not (#{'__extmap '__meta} (:name member)))
                           (:public (:flags member))


### PR DESCRIPTION
AOT compilation is generally inappropriate for libraries.  The AOT compiled classes for all dependencies -- including Clojure itself -- end up in the resulting JAR, arbitrarily overriding the dependencies of any project using that JAR.

This change works around the apparent bug in `clojure.reflect` to avoid the need to AOT in order to reflect on non-AOTed record classes.
