### PR TITLE
Fix the result-binding in compiler

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -195,7 +195,7 @@
                            '?__env__)
 
         ;; Initial bindings used in the return of the compiled condition expresion.
-        initial-bindings (if result-binding {result-binding 'this}  {})]
+        initial-bindings (if result-binding {result-binding '?__fact__}  {})]
 
     `(fn [~(if (symbol? type)
              (with-meta


### PR DESCRIPTION
When destructuring and a result binding was used, the compiler incorrectly
assigned the result-binding from the implicit 'this binding (which didn't
exist).

I think the 'this binding could be dropped altogether.
