### PR TITLE
Add file and line info when eval'ing

### DIFF
--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -42,7 +42,10 @@
       (throw (IllegalArgumentException. "Only one argument can be passed to a condition.")))
 
     (cond-> {:type type
-             :constraints constraints}
+             :constraints constraints
+             :cmeta (if (seq constraints)
+                      (assoc (meta (first constraints))
+                        :file *file*))}
             args (assoc :args args)
             result-binding (assoc :fact-binding result-binding))))
 
@@ -131,8 +134,11 @@
         rule {:lhs (list 'quote
                          (mapv #(resolve-vars % (destructure-syms %))
                                conditions))
-              :rhs (resolve-vars (list 'quote rhs)
-                                 (map :fact-binding conditions))}
+              :rhs (with-meta
+                     (resolve-vars (list 'quote rhs)
+                                   (map :fact-binding conditions))
+                     (assoc (meta rhs) :file *file*))
+              :rhs-meta (assoc (meta rhs) :file *file*)}
 
         symbols (set (filter symbol? (flatten (concat lhs rhs))))
         matching-env (into {} (for [sym (keys env)

--- a/src/main/clojure/clara/rules/schema.clj
+++ b/src/main/clojure/clara/rules/schema.clj
@@ -27,6 +27,7 @@
    :constraints [(s/pred list? "s-expression")]
    (s/optional-key :fact-binding) s/Keyword
    (s/optional-key :args) s/Any
+   (s/optional-key :cmeta) s/Any
    })
 
 (def AccumulatorCondition


### PR DESCRIPTION
When eval'ing constraints and rule bodies, set the file and line information
to that on the original source.  This ensures compile exceptions point to the
original source locations.
