### PR TITLE
Fix potential StackOverflowError when many elements/tokens/activations added to working memory

### DIFF
--- a/src/main/clojure/clara/rules/memory.clj
+++ b/src/main/clojure/clara/rules/memory.clj
@@ -152,7 +152,7 @@
       (set! alpha-memory
             (assoc! alpha-memory
                     (:id node)
-                    (assoc binding-element-map join-bindings (concat previous-elements elements))))))
+                    (assoc binding-element-map join-bindings (into previous-elements elements))))))
 
   (remove-elements! [memory node join-bindings elements]
     (let [binding-element-map (get alpha-memory (:id node) {})
@@ -175,7 +175,7 @@
       (set! beta-memory
             (assoc! beta-memory
                     (:id node)
-                    (assoc binding-token-map join-bindings (concat previous-tokens tokens))))))
+                    (assoc binding-token-map join-bindings (into previous-tokens tokens))))))
 
   (remove-tokens! [memory node join-bindings tokens]
     (let [binding-token-map (get beta-memory (:id node) {})
@@ -229,7 +229,7 @@
 
   (add-activations! [memory new-activations]
     (set! activations
-          (concat activations new-activations)))
+          (into activations new-activations)))
 
   (pop-activation! [memory]
     (let [activation (first activations)


### PR DESCRIPTION
There is potential for a `StackOverflowError` to be thrown in a few scenarios:
1. A large number of elements are added via `clara.rules.memory/add-elements!` from right activations.
2. A large number of tokens are added via `c.r.m/add-tokens!` from left activations.
3. A large number of activations are added via `c.r.m/add-activations!` from rule activations.

The reason for this is that these `add-*!` functions are "piling" up successive calls to `concat`, which is lazy.
When this seq of `concat`ed elements is realized, it needs _n_ number of stack frames to get the first (and successive) element(s) , where _n_ is the "large number of elements/tokens/activations added via" an `add-*!` function.

This looks something like (example from `add-elements!`):

``` clj
(concat previous-elements elements)

```

The most obvious solution to this problem is to swap the `concat` with a `into` instead, which is eagerly evaluated.
However, it is worth considering if the eager evaluation of `into` is appropriate.  Is there a good reason to perform these operations in a lazy manner?  It is not immediately clear to me.

**Also, note that `c.r.m/add-insertions!` has the same nested `concat` call structure in it.  However, I have not reproduced this in a test case yet.  I believe it may need to be addressed in the same way as the 3 places addressed in this issue.  I have left it alone currently.**

Issues like this have been discussed in a number of different threads, but http://stackoverflow.com/questions/5294055/why-am-i-getting-a-stackoverflow  is one example.

In my test cases, I have set the addition count `n` to 6000.  Around ~4K additions to memory is where the StackOverflowError comes up (i.e. whatever the call-stack limitation is).

I've written tests to expose the 3 points above.  I have noted that using batch insertions in these test cases, could workaround the issue.  However, I'm not sure that the memory should be implemented in a way that relies on the rules using batch insertions in all cases where there may be a lot of added elements/tokens/activations.
