### PR TITLE
add env support to expression/accumulator join nodes

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1632,6 +1632,7 @@
             ;; Create an accumulator structure for use when examining the node or the tokens
             ;; it produces.
             {:accumulator (:accumulator beta-node)
+             :env (:env beta-node)
              ;; Include the original filter expressions in the constraints for inspection tooling.
              :from (update-in condition [:constraints]
                               into (-> beta-node :join-filter-expressions :constraints))}

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1348,6 +1348,27 @@
 
     (is (= 42 @rule-output-env))))
 
+(deftest test-destructured-join-node-env-binding
+  (let [rule-output-env (atom #{})
+        rule {:name "clara.test-destructured-binding/test-destructured-test-env-binding"
+              :env {:rule-output rule-output-env} ; Rule environment so we can check its output.
+              :lhs '[{:args [[e a v]]
+                      :type :foo
+                      :constraints [(= e ?entity) (= v ?foo-value) (swap! rule-output conj ?foo-value)]}
+                     {:accumulator (clara.rules.accumulators/all),
+                      :from
+                      {:args [[e a v]]
+                       :type :bar
+                       :constraints [(= e ?entity) (= v ?bar-value) (swap! rule-output conj ?bar-value)]},
+                      :result-binding :?resp}]
+              :rhs '(inc 1)}]
+    (-> (mk-session [rule] :fact-type-fn second)
+        (insert [1 :foo 42])
+        (insert [1 :bar 43])
+        (fire-rules))
+
+    (is (= #{42 43} @rule-output-env))))
+
 (def locals-shadowing-tester
   "Used to demonstrate local shadowing works in `test-explicit-rhs-map-can-use-ns-name-for-unqualified-symbols` below."
   :bad)


### PR DESCRIPTION
This is a follow up for #485 where I noticed there were additional code paths involving join nodes where the `env` was not passed through to the compiled join node handlers.