### PR TITLE
fix clj-kondo treats docstring as function name

### DIFF
--- a/clj-kondo/clj-kondo.exports/clara/rules/hooks/clara_rules.clj_kondo
+++ b/clj-kondo/clj-kondo.exports/clara/rules/hooks/clara_rules.clj_kondo
@@ -242,8 +242,10 @@
   "analyze clara-rules defquery macro"
   [{:keys [:node]}]
   (let [[production-name & children] (rest (:children node))
-        production-docs (when (= :token (node-type (first children)))
-                          (first children))
+        ;; Skip docstring if it's a string literal node
+        [children production-docs] (if (= :string (node-type (first children)))
+                                   [(rest children) (first children)]
+                                   [children nil])
         children (if production-docs (rest children) children)
         production-opts (when (= :map (node-type (first children)))
                           (first children))
@@ -347,8 +349,10 @@
   "analyze clara-rules defrule macro"
   [{:keys [:node]}]
   (let [[production-name & children] (rest (:children node))
-        production-docs (when (= :token (node-type (first children)))
-                          (first children))
+        ;; Skip docstring if it's a string literal node
+        [children production-docs] (if (= :string (node-type (first children)))
+                                   [(rest children) (first children)]
+                                   [children nil])
         children (if production-docs (rest children) children)
         production-opts (when (= :map (node-type (first children)))
                           (first children))


### PR DESCRIPTION
got bellow error with `clj-kondo --cache false --lint foo.clj` 
`function name must be a simple symbol but got: "doc string"`

clj-kondo treats doc string in `defrule` and `defquery` as function name
this PR skips the doc string if it's a string node


![CleanShot 2024-10-25 at 14 34 52@2x](https://github.com/user-attachments/assets/d62ad2ae-6c5d-4f85-b878-8728eb7022b7)
